### PR TITLE
Update participants.csv

### DIFF
--- a/participants.csv
+++ b/participants.csv
@@ -28,7 +28,7 @@ Gina Helfrich,NumFOCUS
 Chris Hill,Massachusetts Institute of Technology
 Chris Holdgraf,Berkeley Institute for Data Science
 James Howison,"University of Texas, Austin"
-Katy Huff,University of Illinois Urbana-Champaign
+Kathryn Huff,University of Illinois Urbana-Champaign
 Lorraine Hwang,"University of California, Davis"
 Raymond Idaszak,RENCI
 Kenneth Jansen,University of Colorado


### PR DESCRIPTION
In case it ends up on any kinds of official documents, best to use Kathryn rather than Katy.